### PR TITLE
Support non-format templates

### DIFF
--- a/lib/discover-unused-partials.rb
+++ b/lib/discover-unused-partials.rb
@@ -116,8 +116,8 @@ module DiscoverUnusedPartials
       partials.uniq!
       [partials, dynamic]
     end
-    
-    EXT = %w(.html.erb .text.erb .html.haml .text.haml .rhtml)
+
+    EXT = %w(.html.erb .text.erb .erb .html.haml .text.haml .haml .rhtml)
     def check_extension_path(file)
       "#{file}#{EXT.find{ |e| File.exists? file + e }}"
     end


### PR DESCRIPTION
for example, `_partial.erb` or `_partial.haml`
