### PR TITLE
Match same file with different extensions

### DIFF
--- a/lib/discover-unused-partials.rb
+++ b/lib/discover-unused-partials.rb
@@ -117,7 +117,7 @@ module DiscoverUnusedPartials
       [partials, dynamic]
     end
 
-    EXT = %w(.html.erb .text.erb .pdf.erb .erb .html.haml .text.haml .haml .rhtml .html.slim slim)
+    EXT = %w(.html.erb .text.erb .pdf.erb .erb .html.haml .text.haml .haml .rhtml .html.slim .slim .html.inky-haml .html)
     def check_extension_path(file)
       "#{file}#{EXT.find{ |e| File.exists? file + e }}"
     end

--- a/lib/discover-unused-partials.rb
+++ b/lib/discover-unused-partials.rb
@@ -101,7 +101,7 @@ module DiscoverUnusedPartials
                   full_path = "#{file.split('/')[0...-1].join('/')}/_#{match}"
                 end
               end
-              partials << check_extension_path(full_path)
+              partials += check_extension_path(full_path)
             elsif line =~ /#@@partial|#@@render["']/
               if @options["dynamic"] && @options["dynamic"][file]
                 partials += @options["dynamic"][file]
@@ -119,7 +119,11 @@ module DiscoverUnusedPartials
 
     EXT = %w(.html.erb .text.erb .pdf.erb .erb .html.haml .text.haml .haml .rhtml .html.slim .slim .html.inky-haml .html)
     def check_extension_path(file)
-      "#{file}#{EXT.find{ |e| File.exists? file + e }}"
+      EXT.map do |e|
+        file + e
+      end.select do |file_with_extension|
+        File.exists?(file_with_extension)
+      end
     end
 
     def each_file(root, &block)


### PR DESCRIPTION
Thank you for creating this wonderful gem! It saves me ton of times to manually finding all unused partials and remove them. I would love to contribute a tiny change to make this gem even more awesome.

## Context

I have some partials which are used for rendering email. Because my application supports sending email in plain text and html, I have two files with same name and different extensions (`text.erb` and `html.haml`) for each partial. The current script can only detect one file, and the other is reported as unused.

## Change

- Return all existed files that match `name + extension` in `#check_extension_path` so that they can be filtered correctly.
- Add more extensions: `html` and `html.inky-haml`
- Fix `slim` extension cannot be matched.