### PR TITLE
Handle unexpected character encodings

### DIFF
--- a/lib/discover-unused-partials.rb
+++ b/lib/discover-unused-partials.rb
@@ -85,7 +85,10 @@ module DiscoverUnusedPartials
       files.each do |file|
         File.open(file) do |f|
           f.each do |line|
-            line.strip!
+            line = line.
+              encode("UTF-8", "binary", invalid: :replace, undef: :replace, replace: "").
+              strip
+
             if line =~ %r[(?:#@@partial|#@@render)(['"])/?(#@@filename)#@@extension*\1]
               match = $2
               if match.index("/")


### PR DESCRIPTION
Some files cause encoding issues that break the template crawler. The
reports on #15 range from Ruby version to template type to file encoding
differences.

This change uses a somewhat brute force approach to work around the
issue by dropping unexpected characters inspired by this blog post:

https://thoughtbot.com/blog/fight-back-utf-8-invalid-byte-sequences

After this change we were able to crawl and parse our templates
successfully.

Close #15